### PR TITLE
Fixed names of wandb configs for Habitat benchmarks

### DIFF
--- a/cortexbench/habitat2_vc/configs/wandb_habitat/habitat2.yaml
+++ b/cortexbench/habitat2_vc/configs/wandb_habitat/habitat2.yaml
@@ -5,4 +5,4 @@ WANDB:
   run_name: habitat_rearrange
   name    : ${model.metadata.algo}_${model.metadata.model}_${model.metadata.data}_${model.metadata.comment}_${WANDB.run_name}
   group   : ${habitat.gym.auto_name}
-  entity  : ???
+  entity  : cortexbench

--- a/cortexbench/habitat_vc/configs/wandb_habitat/habitat_eaif.yaml
+++ b/cortexbench/habitat_vc/configs/wandb_habitat/habitat_eaif.yaml
@@ -1,7 +1,0 @@
-WANDB:
-  project : habitat_eaif
-  entity  : eai-foundations
-  resume  : allow
-  mode    : online
-  run_name: imagenav_run
-  name    : ${model.metadata.algo}_${model.metadata.model}_${model.metadata.data}_${WANDB.run_name}

--- a/cortexbench/habitat_vc/configs/wandb_habitat/habitat_objectnav_eaif.yaml
+++ b/cortexbench/habitat_vc/configs/wandb_habitat/habitat_objectnav_eaif.yaml
@@ -1,7 +1,0 @@
-WANDB:
-  project : habitat_objectnav_eaif
-  entity  : eai-foundations
-  resume  : allow
-  mode    : online
-  run_name: objectnav_run
-  name    : ${model.metadata.algo}_${model.metadata.model}_${model.metadata.data}_${WANDB.run_name}


### PR DESCRIPTION
Fixed names of wandb configs for Habitat benchmarks as it refers in the main evaluation configs.